### PR TITLE
Refactor: db_serial module

### DIFF
--- a/main/db_esp32_control.c
+++ b/main/db_esp32_control.c
@@ -619,7 +619,7 @@ control_module_esp_now()
       default:
         // No parsing with any other protocol - transparent here - just pass
         // through
-        write_to_serial(db_espnow_uart_evt.data, db_espnow_uart_evt.data_len);
+        db_write_to_serial(db_espnow_uart_evt.data, db_espnow_uart_evt.data_len);
         break;
       }
 
@@ -856,7 +856,7 @@ control_module_udp_tcp()
 
           default:
             // No parsing with any other protocol - transparent here
-            write_to_serial(tcp_client_buffer, recv_length);
+            db_write_to_serial(tcp_client_buffer, recv_length);
             break;
           }
         }
@@ -902,7 +902,7 @@ control_module_udp_tcp()
 
       default:
         // No parsing with any other protocol - transparent here
-        write_to_serial(udp_buffer, recv_length);
+        db_write_to_serial(udp_buffer, recv_length);
         break;
       }
 
@@ -931,7 +931,7 @@ control_module_udp_tcp()
                              &udp_socklen);
       if(recv_length > 0) {
         // no parsing - transparent here
-        write_to_serial(udp_buffer, recv_length);
+        db_write_to_serial(udp_buffer, recv_length);
         // add Skybrush server to known UDP target/distribution list
         add_to_known_udp_clients(udp_conn_list, new_db_udp_client, false);
       }
@@ -1055,7 +1055,7 @@ control_module_ble()
       else {
         // no parsing with any other protocol - transparent here - just pass
         // through
-        write_to_serial(bleData.data, bleData.data_len);
+        db_write_to_serial(bleData.data, bleData.data_len);
       }
       free(bleData.data);
     }

--- a/main/db_mavlink_msgs.c
+++ b/main/db_mavlink_msgs.c
@@ -376,7 +376,7 @@ handle_mavlink_message(fmav_message_t *new_msg, int *tcp_clients,
           ESP_LOGD(TAG, "Sending back heartbeat via serial link to GCS");
           // In AP LR mode and in ESP-NOW GND mode the heartbeat has to be
           // emitted via serial directly to the GCS
-          write_to_serial(buff, length);
+          db_write_to_serial(buff, length);
         }
         else {
           ESP_LOGW(TAG,

--- a/main/db_serial.c
+++ b/main/db_serial.c
@@ -1,4 +1,4 @@
-/*
+/******************************************************************************
  *   This file is part of DroneBridge: https://github.com/DroneBridge/ESP32
  *
  *   Copyright 2024 Wolfgang Christl
@@ -15,28 +15,47 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  *
- */
+ ******************************************************************************/
 
-#include "lwip/sockets.h"
-#include "esp_log.h"
-#include <esp_wifi.h>
-#include <esp_timer.h>
-#include <lwip/inet.h>
-#include <esp_vfs_dev.h>
-#include <esp_task_wdt.h>
+/******************************************************************************
+ * System & Standard Library Headers
+ ******************************************************************************/
 #include <string.h>
+#include <stdint-gcc.h>
 #include <sys/param.h>
 #include <sys/fcntl.h>
 #include <sys/cdefs.h>
-#include <stdint-gcc.h>
+
+/******************************************************************************
+ * LwIP & Networking
+ ******************************************************************************/
+#include "lwip/sockets.h"
+#include <lwip/inet.h>
+
+/******************************************************************************
+ * ESP-IDF Core APIs
+ ******************************************************************************/
+#include "esp_log.h"
+#include <esp_wifi.h>
+#include <esp_timer.h>
+#include <esp_vfs_dev.h>
+#include <esp_task_wdt.h>
+
+/******************************************************************************
+ * ESP-IDF Driver APIs
+ ******************************************************************************/
 #include <driver/usb_serial_jtag.h>
-#include "db_serial.h"
-#include "main.h"
-#include "db_esp32_control.h"
-#include "db_protocol.h"
-#include "msp_ltm_serial.h"
-#include "globals.h"
 #include "driver/uart.h"
+
+/******************************************************************************
+ * Project Headers
+ ******************************************************************************/
+#include "main.h"
+#include "globals.h"
+#include "db_serial.h"
+#include "db_protocol.h"
+#include "db_esp32_control.h"
+#include "msp_ltm_serial.h"
 #include <db_parameters.h>
 
 #define FASTMAVLINK_ROUTER_LINKS_MAX 3
@@ -56,7 +75,11 @@ uint ltm_frames_in_buffer_pnt = 0;
 
 fmav_message_t msg;
 
-/**
+/******************************************************************************
+ * Private Function Declaration
+ ******************************************************************************/
+
+/******************************************************************************
  * Opens UART socket.
  * Enables UART flow control if RTS and CTS pins do NOT match.
  * Only open serial socket/UART if PINs are not matching - matching PIN nums
@@ -65,8 +88,40 @@ fmav_message_t msg;
  *
  * 8 data bits, no parity, 1 stop bit
  * @return ESP_ERROR or ESP_OK
- */
-esp_err_t
+ ******************************************************************************/
+static esp_err_t open_uart_serial_socket();
+
+#ifdef CONFIG_DB_SERIAL_OPTION_JTAG
+/******************************************************************************
+ * Configures the onboard USB/JTAG interface for serial communication (instead
+ * of an UART). Board must support this interface.
+ *
+ * @return result of usb_serial_jtag_driver_install()
+ ******************************************************************************/
+static esp_err_t open_jtag_serial_socket();
+#endif
+
+/******************************************************************************
+ * Read data from the open serial interface in non-blocking fashion.
+ * @param uart_read_buf Pointer to buffer to put the read bytes into
+ * @param length Max length to read
+ * @return number of read bytes
+ ******************************************************************************/
+static int db_read_serial(uint8_t *uart_read_buf, uint length);
+
+/******************************************************************************
+ * Check armed state of LTM packet if feature DB_PARAM_DIS_RADIO_ON_ARM is set
+ * and we got a status frame. Triggers the enabling or disabling of the Wi-Fi.
+ * @param db_msp_ltm_port MSP/LTM parser struct
+ ******************************************************************************/
+static void
+ltm_check_arm_state_set_wifi(const msp_ltm_port_t *db_msp_ltm_port);
+
+/******************************************************************************
+ * Private Function Definition
+ ******************************************************************************/
+
+static esp_err_t
 open_uart_serial_socket()
 {
   // only open serial socket/UART if PINs are not matching - matching PIN nums
@@ -107,13 +162,8 @@ open_uart_serial_socket()
   return uart_driver_install(UART_NUM, 1024, 0, 10, NULL, 0);
 }
 
-/**
- * Configures the onboard USB/JTAG interface for serial communication (instead
- * of an UART). Board must support this interface.
- *
- * @return result of usb_serial_jtag_driver_install()
- */
-esp_err_t
+#ifdef CONFIG_DB_SERIAL_OPTION_JTAG
+static esp_err_t
 open_jtag_serial_socket()
 {
   // Configure USB SERIAL JTAG
@@ -124,17 +174,43 @@ open_jtag_serial_socket()
   ESP_LOGI(TAG, "Initializing USB/JTAG serial interface.");
   return usb_serial_jtag_driver_install(&usb_serial_jtag_config);
 }
+#endif
 
-/**
- * Opens a serial socket for communication with a serial source. On the GND
- * this is the GCS and on the air side this is the flight controller. Depending
- * on the configuration it may open a native UART socket or a JTAG based serial
- * interface. The JTAG serial based interface is a special feature of official
- * DroneBridge for ESP32 boards. Uses the onboard USB for serial I/O with GCS.
- * No FTDI required.
- *
- * @return ESP_FAIL on failure
- */
+static int
+db_read_serial(uint8_t *uart_read_buf, uint length)
+{
+#ifdef CONFIG_DB_SERIAL_OPTION_JTAG
+  return usb_serial_jtag_read_bytes(uart_read_buf, length, 0);
+#else
+  // UART based serial socket for communication with FC or GCS via FTDI -
+  // configured by pins in the web interface
+  return uart_read_bytes(UART_NUM, uart_read_buf, length, 0);
+#endif
+}
+
+static void
+ltm_check_arm_state_set_wifi(const msp_ltm_port_t *db_msp_ltm_port)
+{
+  if(DB_PARAM_DIS_RADIO_ON_ARM && db_msp_ltm_port->ltm_type == LTM_TYPE_S) {
+    if(db_msp_ltm_port->ltm_frame_buffer[2 + LTM_TYPE_S_PAYLOAD_SIZE] &
+       LTM_ARMED_BIT_MASK) {
+      // autopilot says it is armed
+      db_set_radio_status(false); // disable Wi-Fi
+    }
+    else {
+      // autopilot says it is <<not>> armed
+      db_set_radio_status(true); // enable Wi-Fi
+    }
+  }
+  else {
+    // nothing to do
+  }
+}
+
+/******************************************************************************
+ * Public Function Definition
+ ******************************************************************************/
+
 esp_err_t
 open_serial_socket()
 {
@@ -150,13 +226,8 @@ open_serial_socket()
 #endif
 }
 
-/**
- * Writes data from buffer to the opened serial device
- * @param data_buffer Payload to write to UART
- * @param data_length Size of payload to write to UART
- */
 void
-write_to_serial(const uint8_t data_buffer[], const unsigned int data_length)
+db_write_to_serial(const uint8_t data_buffer[], const unsigned int data_length)
 {
 #ifdef CONFIG_DB_SERIAL_OPTION_JTAG
   // Writes data from buffer to JTAG based serial interface
@@ -183,52 +254,6 @@ write_to_serial(const uint8_t data_buffer[], const unsigned int data_length)
 #endif
 }
 
-/**
- * Read data from the open serial interface in non-blocking fashion.
- * @param uart_read_buf Pointer to buffer to put the read bytes into
- * @param length Max length to read
- * @return number of read bytes
- */
-int
-db_read_serial(uint8_t *uart_read_buf, uint length)
-{
-#ifdef CONFIG_DB_SERIAL_OPTION_JTAG
-  return usb_serial_jtag_read_bytes(uart_read_buf, length, 0);
-#else
-  // UART based serial socket for communication with FC or GCS via FTDI -
-  // configured by pins in the web interface
-  return uart_read_bytes(UART_NUM, uart_read_buf, length, 0);
-#endif
-}
-
-/**
- * Check armed state of LTM packet if feature DB_PARAM_DIS_RADIO_ON_ARM is set
- * and we got a status frame. Triggers the enabling or disabling of the Wi-Fi.
- * @param db_msp_ltm_port MSP/LTM parser struct
- */
-void
-db_ltm_check_arm_state_set_wifi(const msp_ltm_port_t *db_msp_ltm_port)
-{
-  if(DB_PARAM_DIS_RADIO_ON_ARM && db_msp_ltm_port->ltm_type == LTM_TYPE_S) {
-    if(db_msp_ltm_port->ltm_frame_buffer[2 + LTM_TYPE_S_PAYLOAD_SIZE] &
-       LTM_ARMED_BIT_MASK) {
-      // autopilot says it is armed
-      db_set_radio_status(false); // disable Wi-Fi
-    }
-    else {
-      // autopilot says it is <<not>> armed
-      db_set_radio_status(true); // enable Wi-Fi
-    }
-  }
-  else {
-    // nothing to do
-  }
-}
-
-/**
- * @brief Reads serial interface, parses & sends complete MSP & LTM messages
- * over the air.
- */
 void
 db_parse_msp_ltm(int tcp_clients[], udp_conn_list_t *udp_connection,
                  uint8_t msp_message_buffer[], unsigned int *serial_read_bytes,
@@ -256,7 +281,7 @@ db_parse_msp_ltm(int tcp_clients[], udp_conn_list_t *udp_connection,
                  (db_msp_ltm_port->ltm_payload_cnt + 4));
           ltm_frames_in_buffer_pnt += (db_msp_ltm_port->ltm_payload_cnt + 4);
           ltm_frames_in_buffer++;
-          db_ltm_check_arm_state_set_wifi(db_msp_ltm_port);
+          ltm_check_arm_state_set_wifi(db_msp_ltm_port);
           if(ltm_frames_in_buffer ==
                db_param_ltm_per_packet.value.db_param_u8.value &&
              (db_param_ltm_per_packet.value.db_param_u8.value <=
@@ -281,131 +306,6 @@ db_parse_msp_ltm(int tcp_clients[], udp_conn_list_t *udp_connection,
   }
 }
 
-/**
- * We received some MAVLink request via the origin. Decide on which interface
- * to respond with an answer
- * @param buffer Data to send
- * @param length Data length to send
- * @param origin Origin of the MAVLink request
- * @param tcp_clients List of connected TCP client
- * @param udp_conns List of active UDP connections
- */
-void
-db_route_mavlink_response(uint8_t *buffer, uint16_t length,
-                          enum DB_MAVLINK_DATA_ORIGIN origin, int *tcp_clients,
-                          udp_conn_list_t *udp_conns)
-{
-  if(origin == DB_MAVLINK_DATA_ORIGIN_SERIAL) {
-    write_to_serial(buffer, length);
-  }
-  else if(origin == DB_MAVLINK_DATA_ORIGIN_RADIO) {
-    db_send_to_all_clients(tcp_clients, udp_conns, buffer, length);
-  }
-  else {
-    ESP_LOGE(TAG, "Unknown msg origin. Do not know on which link to respond!");
-  }
-}
-
-/**
- * Parses MAVLink coming from WiFi/ESPNOW - and sends the packet to the serial
- * output.
- *
- * @param tcp_clients Array of connected TCP clients
- * @param up_conns Structure containing all UDP connection data including the
- * sockets
- * @param buffer Buffer containing the raw bytes to be parsed
- * @param bytes_read Number of bytes in the buffer
- * @param origin Origin of the data - serial link or radio link
- */
-void
-db_parse_mavlink_from_radio(int *tcp_clients, udp_conn_list_t *udp_conns,
-                            uint8_t *buffer, int bytes_read)
-{
-  static uint8_t mav_parser_rx_buf[296]; // at least 280 bytes which is the max
-                                         // len for a MAVLink v2 packet
-  static fmav_status_t fmav_status_radio; // fmav parser status struct for
-                                          // radio/ESPNOW/WiFi parser
-
-  // Parse each byte received
-  for(int i = 0; i < bytes_read; ++i) {
-    fmav_result_t result = { 0 };
-    if(fmav_parse_and_check_to_frame_buf(
-         &result, mav_parser_rx_buf, &fmav_status_radio, buffer[i])) {
-      // Parser detected a full message, write to serial
-      write_to_serial(mav_parser_rx_buf, result.frame_len);
-      // Decode message and react to it if it was for us
-      fmav_frame_buf_to_msg(&msg, &result, mav_parser_rx_buf);
-      if(result.res == FASTMAVLINK_PARSE_RESULT_OK) {
-        if(fmav_msg_is_for_me(
-             db_get_mav_sys_id(), db_get_mav_comp_id(), &msg)) {
-          handle_mavlink_message(&msg,
-                                 tcp_clients,
-                                 udp_conns,
-                                 &fmav_status_radio,
-                                 DB_MAVLINK_DATA_ORIGIN_RADIO);
-        }
-        else {
-          // message was not for us so ignore it
-        }
-      }
-      else {
-        switch(result.res) {
-        case FASTMAVLINK_PARSE_RESULT_MSGID_UNKNOWN:
-          ESP_LOGW(TAG,
-                   "fastmavlink parser had an error "
-                   "FASTMAVLINK_PARSE_RESULT_MSGID_UNKNOWN msgID: %lu",
-                   result.msgid);
-          break;
-        case FASTMAVLINK_PARSE_RESULT_LENGTH_ERROR:
-          ESP_LOGW(TAG,
-                   "fastmavlink parser had an error "
-                   "FASTMAVLINK_PARSE_RESULT_LENGTH_ERROR msgID: %lu",
-                   result.msgid);
-          break;
-        case FASTMAVLINK_PARSE_RESULT_CRC_ERROR:
-          ESP_LOGW(TAG,
-                   "fastmavlink parser had an error "
-                   "FASTMAVLINK_PARSE_RESULT_CRC_ERROR msgID: %lu",
-                   result.msgid);
-          break;
-        case FASTMAVLINK_PARSE_RESULT_SIGNATURE_ERROR:
-          ESP_LOGW(TAG,
-                   "fastmavlink parser had an error "
-                   "FASTMAVLINK_PARSE_RESULT_SIGNATURE_ERROR msgID: %lu",
-                   result.msgid);
-          break;
-        default:
-          ESP_LOGW(TAG,
-                   "fastmavlink parser had an error parsing the message: %i",
-                   result.res);
-          break;
-        }
-      }
-    }
-    else {
-      // do nothing since parser did not detect a message
-    }
-  }
-  // done parsing all received data via radio link
-}
-
-/**
- * Parses MAVLink messages and sends them via the radio link.
- * This function reads data from the serial interface, parses it for complete
- * MAVLink messages, and sends those messages in a buffer. It ensures that only
- * complete messages are sent and that the buffer does not exceed
- * TRANS_BUFF_SIZE. Checks for a serial read timeout. In case timeout is
- * reached all data read from serial so far will be flushed to radio interface
- * The parsing is done semi-transparent as in: parser understands the MavLink
- * frame format but performs no further checks
- *
- * @param tcp_clients Array of connected TCP clients
- * @param up_conns Structure containing all UDP connection data including the
- * sockets
- * @param serial_buffer Buffer that gets filled with data and then sent via
- * radio, shall be >x2 the max payload
- * @param serial_buff_pos Number of bytes already read for the current packet
- */
 void
 db_read_serial_parse_mavlink(int *tcp_clients, udp_conn_list_t *udp_conns,
                              uint8_t *serial_buffer,
@@ -539,19 +439,6 @@ db_read_serial_parse_mavlink(int *tcp_clients, udp_conn_list_t *udp_conns,
   // done parsing all received data via UART
 }
 
-/**
- * Reads TRANS_RD_BYTES_NUM bytes from serial interface and checks if we
- * already got enough bytes to send them out. Timeout ensures that no data is
- * getting stuck in the buffer. Once serial read timeout is reached, the buffer
- * will be flushed to the radio interface (send what we have)
- *
- * @param tcp_clients Array of connected TCP clients
- * @param udp_connection Structure containing all UDP connection data including
- * the sockets
- * @param serial_buffer Buffer that gets filled with data and then sent via
- * radio
- * @param serial_read_bytes Number of bytes already read for the current packet
- */
 void
 db_read_serial_parse_transparent(int tcp_clients[],
                                  udp_conn_list_t *udp_connection,
@@ -590,5 +477,93 @@ db_read_serial_parse_transparent(int tcp_clients[],
       tcp_clients, udp_connection, serial_buffer, *serial_read_bytes);
     *serial_read_bytes = 0;              // reset buffer position
     serial_read_timeout_reached = false; // reset serial read timeout
+  }
+}
+
+void
+db_parse_mavlink_from_radio(int *tcp_clients, udp_conn_list_t *udp_conns,
+                            uint8_t *buffer, int bytes_read)
+{
+  static uint8_t mav_parser_rx_buf[296]; // at least 280 bytes which is the max
+                                         // len for a MAVLink v2 packet
+  static fmav_status_t fmav_status_radio; // fmav parser status struct for
+                                          // radio/ESPNOW/WiFi parser
+
+  // Parse each byte received
+  for(int i = 0; i < bytes_read; ++i) {
+    fmav_result_t result = { 0 };
+    if(fmav_parse_and_check_to_frame_buf(
+         &result, mav_parser_rx_buf, &fmav_status_radio, buffer[i])) {
+      // Parser detected a full message, write to serial
+      db_write_to_serial(mav_parser_rx_buf, result.frame_len);
+      // Decode message and react to it if it was for us
+      fmav_frame_buf_to_msg(&msg, &result, mav_parser_rx_buf);
+      if(result.res == FASTMAVLINK_PARSE_RESULT_OK) {
+        if(fmav_msg_is_for_me(
+             db_get_mav_sys_id(), db_get_mav_comp_id(), &msg)) {
+          handle_mavlink_message(&msg,
+                                 tcp_clients,
+                                 udp_conns,
+                                 &fmav_status_radio,
+                                 DB_MAVLINK_DATA_ORIGIN_RADIO);
+        }
+        else {
+          // message was not for us so ignore it
+        }
+      }
+      else {
+        switch(result.res) {
+        case FASTMAVLINK_PARSE_RESULT_MSGID_UNKNOWN:
+          ESP_LOGW(TAG,
+                   "fastmavlink parser had an error "
+                   "FASTMAVLINK_PARSE_RESULT_MSGID_UNKNOWN msgID: %lu",
+                   result.msgid);
+          break;
+        case FASTMAVLINK_PARSE_RESULT_LENGTH_ERROR:
+          ESP_LOGW(TAG,
+                   "fastmavlink parser had an error "
+                   "FASTMAVLINK_PARSE_RESULT_LENGTH_ERROR msgID: %lu",
+                   result.msgid);
+          break;
+        case FASTMAVLINK_PARSE_RESULT_CRC_ERROR:
+          ESP_LOGW(TAG,
+                   "fastmavlink parser had an error "
+                   "FASTMAVLINK_PARSE_RESULT_CRC_ERROR msgID: %lu",
+                   result.msgid);
+          break;
+        case FASTMAVLINK_PARSE_RESULT_SIGNATURE_ERROR:
+          ESP_LOGW(TAG,
+                   "fastmavlink parser had an error "
+                   "FASTMAVLINK_PARSE_RESULT_SIGNATURE_ERROR msgID: %lu",
+                   result.msgid);
+          break;
+        default:
+          ESP_LOGW(TAG,
+                   "fastmavlink parser had an error parsing the message: %i",
+                   result.res);
+          break;
+        }
+      }
+    }
+    else {
+      // do nothing since parser did not detect a message
+    }
+  }
+  // done parsing all received data via radio link
+}
+
+void
+db_route_mavlink_response(uint8_t *buffer, uint16_t length,
+                          enum DB_MAVLINK_DATA_ORIGIN origin, int *tcp_clients,
+                          udp_conn_list_t *udp_conns)
+{
+  if(origin == DB_MAVLINK_DATA_ORIGIN_SERIAL) {
+    db_write_to_serial(buffer, length);
+  }
+  else if(origin == DB_MAVLINK_DATA_ORIGIN_RADIO) {
+    db_send_to_all_clients(tcp_clients, udp_conns, buffer, length);
+  }
+  else {
+    ESP_LOGE(TAG, "Unknown msg origin. Do not know on which link to respond!");
   }
 }

--- a/main/db_serial.h
+++ b/main/db_serial.h
@@ -1,4 +1,4 @@
-/*
+/******************************************************************************
  *   This file is part of DroneBridge: https://github.com/DroneBridge/ESP32
  *
  *   Copyright 2024 Wolfgang Christl
@@ -15,7 +15,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  *
- */
+ ******************************************************************************/
 
 #ifndef DB_ESP32_DB_SERIAL_H
 #define DB_ESP32_DB_SERIAL_H
@@ -46,21 +46,100 @@ typedef union
   int32_t int32;
 } float_int_union;
 
-int open_serial_socket();
-void write_to_serial(const uint8_t data_buffer[], unsigned int data_length);
+/******************************************************************************
+ * Public Function Declaration
+ ******************************************************************************/
+
+/******************************************************************************
+ * Opens a serial socket for communication with a serial source. On the GND
+ * this is the GCS and on the air side this is the flight controller. Depending
+ * on the configuration it may open a native UART socket or a JTAG based serial
+ * interface. The JTAG serial based interface is a special feature of official
+ * DroneBridge for ESP32 boards. Uses the onboard USB for serial I/O with GCS.
+ * No FTDI required.
+ *
+ * @return ESP_FAIL on failure
+ ******************************************************************************/
+esp_err_t open_serial_socket();
+
+/******************************************************************************
+ * Writes data from buffer to the opened serial device
+ * @param data_buffer Payload to write to UART
+ * @param data_length Size of payload to write to UART
+ ******************************************************************************/
+void db_write_to_serial(const uint8_t data_buffer[], unsigned int data_length);
+
+/******************************************************************************
+ * @brief Reads serial interface, parses & sends complete MSP & LTM messages
+ * over the air.
+ ******************************************************************************/
 void db_parse_msp_ltm(int tcp_clients[], udp_conn_list_t *udp_connection,
                       uint8_t msp_message_buffer[],
                       unsigned int *serial_read_bytes,
                       msp_ltm_port_t *db_msp_ltm_port);
+
+/******************************************************************************
+ * Parses MAVLink messages and sends them via the radio link.
+ * This function reads data from the serial interface, parses it for complete
+ * MAVLink messages, and sends those messages in a buffer. It ensures that only
+ * complete messages are sent and that the buffer does not exceed
+ * TRANS_BUFF_SIZE. Checks for a serial read timeout. In case timeout is
+ * reached all data read from serial so far will be flushed to radio interface
+ * The parsing is done semi-transparent as in: parser understands the MavLink
+ * frame format but performs no further checks
+ *
+ * @param tcp_clients Array of connected TCP clients
+ * @param up_conns Structure containing all UDP connection data including the
+ * sockets
+ * @param serial_buffer Buffer that gets filled with data and then sent via
+ * radio, shall be >x2 the max payload
+ * @param serial_buff_pos Number of bytes already read for the current packet
+ ******************************************************************************/
 void db_read_serial_parse_mavlink(int *tcp_clients, udp_conn_list_t *udp_conns,
                                   uint8_t *serial_buffer,
                                   unsigned int *serial_buff_pos);
+
+/******************************************************************************
+ * Reads TRANS_RD_BYTES_NUM bytes from serial interface and checks if we
+ * already got enough bytes to send them out. Timeout ensures that no data is
+ * getting stuck in the buffer. Once serial read timeout is reached, the buffer
+ * will be flushed to the radio interface (send what we have)
+ *
+ * @param tcp_clients Array of connected TCP clients
+ * @param udp_connection Structure containing all UDP connection data including
+ * the sockets
+ * @param serial_buffer Buffer that gets filled with data and then sent via
+ * radio
+ * @param serial_read_bytes Number of bytes already read for the current packet
+ ******************************************************************************/
 void db_read_serial_parse_transparent(int tcp_clients[],
                                       udp_conn_list_t *udp_connection,
                                       uint8_t serial_buffer[],
                                       unsigned int *serial_read_bytes);
+
+/******************************************************************************
+ * Parses MAVLink coming from WiFi/ESPNOW - and sends the packet to the serial
+ * output.
+ *
+ * @param tcp_clients Array of connected TCP clients
+ * @param up_conns Structure containing all UDP connection data including the
+ * sockets
+ * @param buffer Buffer containing the raw bytes to be parsed
+ * @param bytes_read Number of bytes in the buffer
+ * @param origin Origin of the data - serial link or radio link
+ ******************************************************************************/
 void db_parse_mavlink_from_radio(int *tcp_clients, udp_conn_list_t *udp_conns,
                                  uint8_t *buffer, int bytes_read);
+
+/******************************************************************************
+ * We received some MAVLink request via the origin. Decide on which interface
+ * to respond with an answer
+ * @param buffer Data to send
+ * @param length Data length to send
+ * @param origin Origin of the MAVLink request
+ * @param tcp_clients List of connected TCP client
+ * @param udp_conns List of active UDP connections
+ ******************************************************************************/
 void db_route_mavlink_response(uint8_t *buffer, uint16_t length,
                                enum DB_MAVLINK_DATA_ORIGIN origin,
                                int *tcp_clients, udp_conn_list_t *udp_conns);

--- a/main/main.c
+++ b/main/main.c
@@ -852,7 +852,7 @@ db_jtag_serial_info_print()
 {
   uint8_t buffer[512];
   const int len = db_param_print_values_to_buffer(buffer);
-  write_to_serial(buffer, len);
+  db_write_to_serial(buffer, len);
 }
 
 /**


### PR DESCRIPTION
## Coding practices followed

- **Public functions** - All public functions start with the prefix `db_`
- **Private functions** - All private functions should be first declared and then defined also they should be declared as `static`.
- **Doxygen Comments** - The doxygen comments explaining the function should be placed where the function is declared.